### PR TITLE
Fix python issue when using pip install

### DIFF
--- a/centos7/Dockerfile.jdk11
+++ b/centos7/Dockerfile.jdk11
@@ -43,7 +43,7 @@ RUN \
         wget \
         ws-commons-util && \
     yum upgrade python-setuptools && \
-    pip install --upgrade pip && \
+    python3 -m pip install --upgrade pip && \
     wget http://repos.fedorapeople.org/repos/dchen/apache-maven/epel-apache-maven.repo -O /etc/yum.repos.d/epel-apache-maven.repo && \
     yum clean metadata && \
     yum install -y \

--- a/centos7/Dockerfile.jdk8
+++ b/centos7/Dockerfile.jdk8
@@ -43,7 +43,7 @@ RUN \
         wget \
         ws-commons-util && \
     yum upgrade python-setuptools && \
-    pip install --upgrade pip && \
+    python3 -m pip install --upgrade pip && \
     wget http://repos.fedorapeople.org/repos/dchen/apache-maven/epel-apache-maven.repo -O /etc/yum.repos.d/epel-apache-maven.repo && \
     yum clean metadata && \
     yum install -y \


### PR DESCRIPTION
When building the image, it throws an error while running `pip install`:

```sh
Collecting pip
  Downloading https://files.pythonhosted.org/packages/da/f6/c83229dcc3635cdeb51874184241a9508ada15d8baa337a41093fab58011/pip-21.3.1.tar.gz (1.7MB)
    Complete output from command python setup.py egg_info:
    Traceback (most recent call last):
      File "<string>", line 1, in <module>
      File "/tmp/pip-build-L9qAbO/pip/setup.py", line 7
        def read(rel_path: str) -> str:
```

This happens because `pip` syntax was changed on version 3.6+ and it is using a lower version to build de image.
(https://stackoverflow.com/questions/69710274/pip-install-upgrade-fails-with-syntaxerror) 